### PR TITLE
Change temp files to be always written to `./dump`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -26,7 +26,7 @@ To setup the recorder:
 
   1. Install ffmpeg
   2. Thanks to [Danman](https://blog.danman.eu/new-version-of-lenkeng-hdmi-over-ip-extender-lkv373a/) you need to block 0 byte UDP packets that the encoder spits out - use this command: `sudo iptables -t raw -A PREROUTING -p udp -m length --length 28 -j DROP`
-  3. `> cd dump && ffmpeg -skip_frame nokey -i "udp://239.255.42.42:5004?localaddr=169.254.244.97&buffer_size=128000&overrun_nonfatal=1&fifo_size=500000" -vf fps=2 -qscale:v 5 out%04d.jpg`
+  3. `> cd dump && ffmpeg -skip_frame nokey -i "udp://239.255.42.42:5004?localaddr=169.254.244.97&buffer_size=128000&overrun_nonfatal=1&fifo_size=500000" -vf fps=10 -qscale:v 5 out%04d.jpg`
 
 You might need to change the IP addresses - my RaspberryPi v3 can maintain a 2fps (500ms) sample rate - faster computer you could increase the `fps=` sample more images.
 

--- a/Readme.md
+++ b/Readme.md
@@ -26,7 +26,7 @@ To setup the recorder:
 
   1. Install ffmpeg
   2. Thanks to [Danman](https://blog.danman.eu/new-version-of-lenkeng-hdmi-over-ip-extender-lkv373a/) you need to block 0 byte UDP packets that the encoder spits out - use this command: `sudo iptables -t raw -A PREROUTING -p udp -m length --length 28 -j DROP`
-  3. `> cd dump && ffmpeg -skip_frame nokey -i "udp://239.255.42.42:5004?localaddr=169.254.244.97&buffer_size=128000&overrun_nonfatal=1&fifo_size=500000" -vf fps=10 -qscale:v 5 out%04d.jpg`
+  3. `> cd dump && ffmpeg -skip_frame nokey -i "udp://239.255.42.42:5004?localaddr=169.254.244.97&buffer_size=128000&overrun_nonfatal=1&fifo_size=500000" -vf fps=5 -qscale:v 5 out%04d.jpg`
 
 You might need to change the IP addresses - my RaspberryPi v3 can maintain a 2fps (500ms) sample rate - faster computer you could increase the `fps=` sample more images.
 

--- a/analyser.rb
+++ b/analyser.rb
@@ -1,6 +1,7 @@
 require 'phashion'
 require 'time'
 require './screenshot'
+require './screens/screen'
 require './screens/fast_ignore'
 require './screens/main_menu_screen'
 require './screens/race_screen'

--- a/daemon.rb
+++ b/daemon.rb
@@ -11,19 +11,48 @@ raise("You must set a POST_URL env variable - this is where kartalytics will sen
 keep_files = !!ENV['KEEP_FILES']
 uri = URI.parse(ENV['POST_URL'])
 
-Logger = ActiveSupport::Logger.new('analyser.log')
+KartLog = ActiveSupport::Logger.new('analyser.log')
+
+# Analyse every 5th image by default - we'll change this
+# when we're expecting an intro screen (these are often skipped)
+DEFAULT_SAMPLE_RATE = 5
+sample_rate = DEFAULT_SAMPLE_RATE
+
+def should_sample?(filename, sample_rate)
+  File.basename(filename).gsub(/[^\d]/, '').to_i % sample_rate == 0
+end
+
+def should_increase_sample_rate?(event)
+  # If we've seen a loading screen, next screen we're likely to see
+  # is an intro screen - lets bump sample rate to try to grab it
+  event[:event_type] == 'loading_screen'
+end
+
+def should_decrease_sample_rate?(event)
+  # If we've seen any of these screens we don't need to sample faster for a bit
+  event[:event_type] == 'intro_screen' ||
+  event[:event_type] == 'race_screen' ||
+  event[:event_type] == 'main_menu_screen'
+end
 
 loop do
   events = []
 
   begin
     Dir.glob(glob).sort_by {|file|
-      File.ctime(file)
+      # File.ctime(file)
+      File.basename(file)
     }.each do |filename|
-      start = Time.now
-      event = Analyser.analyse!(filename)
+      event = nil
 
-      puts "#{File.basename(filename)} => #{event.inspect} - Time taken: #{Time.now - start}"
+      if should_sample?(filename, sample_rate)
+        start = Time.now
+        event = Analyser.analyse!(filename)
+
+        KartLog.info "#{File.basename(filename)} => #{event.inspect} - Time taken: #{Time.now - start}"
+      else
+        KartLog.info "#{File.basename(filename)} skipped"
+      end
 
       if keep_files
         new_name = filename.to_s.sub('out', 'processed')
@@ -33,11 +62,17 @@ loop do
       end
 
       if event
+        if should_increase_sample_rate?(event)
+          sample_rate = 1
+        elsif should_decrease_sample_rate?(event)
+          sample_rate = 5
+        end
+
         events.push event
       end
     end
   rescue Magick::ImageMagickError => e
-    puts "RMagick error #{e}"
+    KartLog.error "RMagick error #{e}"
   end
 
   if events.any?
@@ -49,7 +84,7 @@ loop do
     request.content_type = "application/json"
     request.body = payload.to_json
 
-    puts request.body
+    KartLog.info request.body
     response = nil
 
     Retriable.retriable on: [Timeout::Error, Errno::ECONNRESET] do
@@ -58,7 +93,7 @@ loop do
       end
     end
 
-    puts "Sending #{events.length} event(s). Response #{response.body}"
+    KartLog.info "Sending #{events.length} event(s). Response #{response.body}"
   end
   sleep(0.2)
 end

--- a/screens/intro_screen.rb
+++ b/screens/intro_screen.rb
@@ -1,4 +1,4 @@
-class IntroScreen
+class IntroScreen < Screen
   COURSES = [
     {file: 'sunshine_airport', name: 'Sunshine Airport'},
     {file: 'dolphin_shoals', name: 'Dolphin Shoals'},
@@ -66,24 +66,19 @@ class IntroScreen
   REFERENCE = Phashion::Image.new("reference_images/intro/intro_reference.jpg")
 
   def self.matches_image?(screenshot)
-    image = screenshot.original.dup.crop!(111, 589, 44, 37).write("tmp.jpg")
-    phash = Phashion::Image.new("tmp.jpg")
+    image = screenshot.original.dup.crop!(111, 589, 44, 37)
+
+    phash = convert_to_phash(image)
 
     phash.distance_from(REFERENCE) < 10
-  ensure
-    image.destroy!
   end
 
   def self.extract_event(screenshot)
     crop = screenshot.original.dup.crop!(258, 620, 350, 36)
     image = crop.black_threshold(50000, 50000, 50000)
-
-    image.write('tmp.jpg')
-
     crop.destroy!
-    image.destroy!
 
-    phash = Phashion::Image.new("tmp.jpg")
+    phash = convert_to_phash(image)
 
     likely_course = COURSES.min_by do |course|
       phash.distance_from(course[:image])

--- a/screens/loading_screen.rb
+++ b/screens/loading_screen.rb
@@ -1,4 +1,4 @@
-class LoadingScreen
+class LoadingScreen < Screen
   # Strat:
   #   Shrink the image right down
   #   Quantize to reduce color space

--- a/screens/main_menu_screen.rb
+++ b/screens/main_menu_screen.rb
@@ -1,4 +1,4 @@
-class MainMenuScreen
+class MainMenuScreen < Screen
   # Strat:
   #   Compare with reference
   REFERENCE = Phashion::Image.new("reference_images/main_menu.jpg")
@@ -7,14 +7,9 @@ class MainMenuScreen
     crop = screenshot.original.dup.crop!(220, 467, 122, 24)
     img = crop.white_threshold(35000, 35000, 35000)
 
-    file_path = 'tmp.jpg'
-
-    img.write(file_path)
-
-    img.destroy!
     crop.destroy!
 
-    phash = Phashion::Image.new(file_path)
+    phash = convert_to_phash(img)
 
     phash.distance_from(REFERENCE) < 10
   end

--- a/screens/match_result_screen.rb
+++ b/screens/match_result_screen.rb
@@ -1,4 +1,4 @@
-class MatchResultScreen
+class MatchResultScreen < Screen
   # Strat:
   #   Compare with reference
   REFERENCE = Phashion::Image.new("reference_images/match_result/reference.jpg")
@@ -7,15 +7,9 @@ class MatchResultScreen
     crop = screenshot.original.dup.crop!(37, 28, 99, 26)
     img = crop.black_threshold(50000, 50000, 50000)
 
-    file_path = '_tmp_delete_me.jpg'
-
-    img.write(file_path)
-
-    img.destroy!
     crop.destroy!
 
-    phash = Phashion::Image.new(file_path)
-
+    phash = convert_to_phash(img)
     phash.distance_from(REFERENCE) < 10
   end
 

--- a/screens/race_result_screen.rb
+++ b/screens/race_result_screen.rb
@@ -1,4 +1,4 @@
-class RaceResultScreen
+class RaceResultScreen < Screen
   # Strat:
   #   Should be splitscreen but not first quarter black
   def self.matches_image?(screenshot)

--- a/screens/race_screen.rb
+++ b/screens/race_screen.rb
@@ -1,4 +1,4 @@
-class RaceScreen
+class RaceScreen < Screen
   # Strat:
   #   First quarter of pixels in centre line should be consistently black
   def self.matches_image?(screenshot)
@@ -71,9 +71,7 @@ class RaceScreen
     FINISH_CROP_XY.keys.each do |player, position|
       img = image.dup.crop!(FINISH_CROP_XY[player][:x], FINISH_CROP_XY[player][:y], 38, 38)
 
-      img.write("tmp.jpg")
-      img.destroy!
-      phash = Phashion::Image.new('tmp.jpg')
+      phash = convert_to_phash(img)
 
       if phash.distance_from(FINISH_REFERENCE) < 10
         positions[player] ||= {}
@@ -90,13 +88,7 @@ class RaceScreen
       img = crop.quantize(256, Magick::GRAYColorspace, Magick::NoDitherMethod)
       crop.destroy!
 
-      phashion_image ||= begin
-        file_path = '_tmp_delete_me.jpg'
-        img.write(file_path)
-        img.destroy!
-        Phashion::Image.new(file_path)
-      end
-
+      phashion_image = convert_to_phash(img)
 
       pos = REFERENCE_IMAGES.min_by do |reference|
         min_distance(phashion_image, reference)

--- a/screens/screen.rb
+++ b/screens/screen.rb
@@ -1,0 +1,7 @@
+class Screen
+  def self.convert_to_phash(image)
+    image.write('dump/tmp.jpg')
+    image.destroy!
+    Phashion::Image.new('dump/tmp.jpg')
+  end
+end

--- a/spec/screens/intro_screen_spec.rb
+++ b/spec/screens/intro_screen_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+describe IntroScreen do
+  describe "matches_image?" do
+    subject { described_class.matches_image?(screenshot) }
+
+    context 'when not an intro screen' do
+      let(:screenshot) { Screenshot.new(fixture('match-result.jpg')) }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when an intro screen' do
+      let(:screenshot) { Screenshot.new(fixture('intro-screen.jpg')) }
+
+      it { is_expected.to be true }
+    end
+  end
+
+  describe "extract_event" do
+    subject { described_class.extract_event(screenshot) }
+
+    let(:screenshot) { Screenshot.new(fixture('intro-screen.jpg')) }
+
+    it 'should extract the course name' do
+      is_expected.to eq({
+        event_type: 'intro_screen',
+        data: {
+          course_name: 'Yoshi Valley (N64)'
+        }
+      })
+    end
+  end
+end

--- a/spec/screens/main_menu_screen_spec.rb
+++ b/spec/screens/main_menu_screen_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe MainMenuScreen do
+  describe "matches_image?" do
+    subject { described_class.matches_image?(screenshot) }
+
+    context 'when not the main menu screen' do
+      let(:screenshot) { Screenshot.new(fixture('match-result.jpg')) }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when the main menu screen' do
+      let(:screenshot) { Screenshot.new(fixture('main-menu.jpg')) }
+
+      it { is_expected.to be true }
+    end
+  end
+end


### PR DESCRIPTION
This means that on a raspberry pi, we can mount `./dump` as a tempfs disk and be able to sample faster (200ms vs 500ms).